### PR TITLE
use isqrt() instead of floor(sqrt())

### DIFF
--- a/deuring.py
+++ b/deuring.py
@@ -93,7 +93,7 @@ class Deuring2D:
         basis_I = ReducedBasis(I.basis())
         N_I = I.norm()
         d = ceil(300*sqrt(self.p))
-        Bs = [floor(sqrt(d/(alpha.reduced_norm()/N_I))/4) for alpha in basis_I]
+        Bs = [isqrt(d/(alpha.reduced_norm()/N_I))//4 for alpha in basis_I]
         print([RR(log(lam/N_I, self.p)) for lam in SuccessiveMinima(I)])
         print(Bs)
         temp = basis_I[0]*basis_I[1].conjugate()

--- a/special_extremal.py
+++ b/special_extremal.py
@@ -35,10 +35,10 @@ class SpecialExtremalOrder:
                 return x + y*self.i
             else:
                 raise ValueError
-        m1 = max(floor(sqrt(round((N)/self.p, 5))), 100)
+        m1 = max(isqrt(N/self.p), 100)
         for _ in range(1000):
             z = randint(-m1, m1)
-            m2 = floor(sqrt(round((N-z**2)/self.p, 5)))
+            m2 = isqrt((N-z**2)/self.p)
             w = randint(-m2, m2)
             Mm = N - self.p*self.QF(z,w)
             x, y, found = self.Cornacchia(Mm)
@@ -58,10 +58,10 @@ class SpecialExtremalOrder:
             else:
                 raise ValueError
             
-        m1 = max(floor(sqrt(round((4*N)/self.p, 5))), 100)
+        m1 = max(isqrt(4*N/self.p), 100)
         for _ in range(1000):
             z = randint(-m1, m1)
-            m2 = floor(sqrt(round((4*N-z**2)/self.p, 5)))
+            m2 = isqrt((4*N-z**2)/self.p)
             w = randint(-m2, m2)
             Mm = 4*N - self.p*self.QF(z,w)
             x, y, found = self.Cornacchia(Mm)


### PR DESCRIPTION
The original version fails for very large inputs since the intermediate floating-point approximation used by `floor()` turns into `inf` in that case. The version using `isqrt()` is more robust (it doesn't rely on floating-point numbers internally).